### PR TITLE
log path edit

### DIFF
--- a/includes/Image.php
+++ b/includes/Image.php
@@ -13,13 +13,19 @@ class Image extends Derivative {
     if (file_exists($this->temp_file)) {
       try {
         $output_file = $this->temp_file . '_JP2.jp2';
-        $command = 'kdu_compress -i ' . $this->temp_file . ' -o ' . $output_file . ' -rate 0.5 Clayers=1 Clevels=7 Cprecincts=\{256,256\},\{256,256\},\{256,256\},\{128,128\},\{128,128\},\{64,64\},\{64,64\},\{32,32\},\{16,16\} Corder=RPCL ORGgen_plt=yes ORGtparts=R Cblk=\{32,32\} Cuse_sop=yes &> /var/log/phpfunctions/cmd1.log';
+        $command = 'kdu_compress -i ' . $this->temp_file . ' -o ' . $output_file . ' -rate 0.5 Clayers=1 Clevels=7 Cprecincts=\{256,256\},\{256,256\},\{256,256\},\{128,128\},\{128,128\},\{64,64\},\{64,64\},\{32,32\},\{16,16\} Corder=RPCL ORGgen_plt=yes ORGtparts=R Cblk=\{32,32\} Cuse_sop=yes 2>&1';
         $jp2_output = array();
         exec($command, $jp2_output, $return);
-        $log_message = "$dsid derivative created using kdu_compress with command - $command || SUCCESS";
-        $this->add_derivative($dsid, $label, $output_file, 'image/jp2', $log_message);
+        if (file_exists($output_file)) {
+          $log_message = "$dsid derivative created using kdu_compress with command - $command || SUCCESS";
+          $this->add_derivative($dsid, $label, $output_file, 'image/jp2', $log_message);
+        }
+        else {
+          $this->log->lwrite("Could not find the file '$output_file' for the HOCR derivative!\nTesseract output: " . implode(', ', $jp2_output) . "\nReturn value: $return", 'FAIL_DATASTREAM', $this->pid, 'JP2', NULL, 'ERROR');
+          return $return;
+        }
       } catch (Exception $e) {
-        $this->log->lwrite("Could not create the $dsid derivative! " . $return . ' ' . implode($jp2_output), 'FAIL_DATASTREAM', $this->pid, $dsid, NULL, 'ERROR');
+        $this->log->lwrite("Could not create the $dsid derivative! " . $return . ' ' . implode(',', $jp2_output), 'FAIL_DATASTREAM', $this->pid, $dsid, NULL, 'ERROR');
         unlink($output_file);
       }
     }
@@ -33,12 +39,18 @@ class Image extends Derivative {
     $this->log->lwrite('Starting processing', 'PROCESS_DATASTREAM', $this->pid, $dsid);
     try {
       $output_file = $this->temp_file . '_TN.jpg';
-      $command = "convert -thumbnail " . $height . "x" . $width . " $this->temp_file $output_file &> /var/log/phpfunctions/cmd1.log";
-      exec($command, $tn_output, $return);
-      $log_message = "$dsid derivative created using ImageMagick with command - $command || SUCCESS";
-      $this->add_derivative($dsid, $label, $output_file, 'image/jpeg', $log_message);
+      $command = "convert -thumbnail " . $height . "x" . $width . " $this->temp_file $output_file 2>&1";
+      exec($command, $tn_output = array(), $return);
+      if (file_exists($output_file)) {
+        $log_message = "$dsid derivative created using ImageMagick with command - $command || SUCCESS";
+        $this->add_derivative($dsid, $label, $output_file, 'image/jpeg', $log_message);
+      }
+      else {
+        $this->log->lwrite("Could not find the file '$output_file' for the Thumbail derivative!\nTesseract output: " . implode(', ', $tn_output) . "\nReturn value: $return", 'FAIL_DATASTREAM', $this->pid, 'TN', NULL, 'ERROR');
+        return $return;
+      }
       } catch (Exception $e) {
-      $this->log->lwrite("Could not create the $dsid derivative!", 'FAIL_DATASTREAM', $this->pid, $dsid, NULL, 'ERROR');
+      $this->log->lwrite("Could not create the $dsid derivative!", $return . ' ' . implode(',', $tn_output), 'FAIL_DATASTREAM', $this->pid, $dsid, NULL, 'ERROR');
       unlink($output_file);
     }
     return $return;
@@ -57,17 +69,24 @@ class Image extends Derivative {
     try {
       $pathinfo = pathinfo($this->temp_file);
       $output_file = $pathinfo['dirname'] . DIRECTORY_SEPARATOR . $pathinfo['filename'] . '_JPG.jpg';
-      if($resize == '0'){
-        $command = "convert $this->temp_file $output_file &> /var/log/phpfunctions/cmd1.log";
-      } else {
-        $command = "convert $this->temp_file -resize $resize $output_file &> /var/log/phpfunctions/cmd1.log";
+      if ($resize == '0') {
+        $command = "convert $this->temp_file $output_file 2>&1";
       }
-      exec($command, $jpg_output, $return);
-      $log_message = "$dsid derivative created using ImageMagick with command - $command || SUCCESS";
-      $this->add_derivative($dsid, $label, $output_file, 'image/jpeg', $log_message);
+      else {
+        $command = "convert $this->temp_file -resize $resize $output_file 2>&1";
+      }
+      exec($command, $jpg_output = array(), $return);
+      if (file_exists($output_file)) {
+        $log_message = "$dsid derivative created using ImageMagick with command - $command || SUCCESS";
+        $this->add_derivative($dsid, $label, $output_file, 'image/jpeg', $log_message);
+      }
+      else {
+        $this->log->lwrite("Could not find the file '$output_file' for the Thumbail derivative!\nTesseract output: " . implode(', ', $JPG_output) . "\nReturn value: $return", 'FAIL_DATASTREAM', $this->pid, 'JPG', NULL, 'ERROR');
+        return $return;
+      }
 
       } catch (Exception $e) {
-      $this->log->lwrite("Could not create the $dsid derivative!", 'FAIL_DATASTREAM', $this->pid, $dsid, NULL, 'ERROR');
+      $this->log->lwrite("Could not create the $dsid derivative!", $return . ' ' . implode(',', $jpg_output), 'FAIL_DATASTREAM', $this->pid, $dsid, NULL, 'ERROR');
       unlink($output_file);
 
       }

--- a/includes/Pdf.php
+++ b/includes/Pdf.php
@@ -11,19 +11,28 @@ class Pdf extends Derivative {
       $this->log->lwrite('Starting processing because the ' . $this->created_datastream . ' datastream was added', 'PROCESS_DATASTREAM', $this->pid, $dsid);
       try {
         $output_file = $this->temp_file . '_Scholar_PDFA.pdf';
+        $pdfa_output=array();
         if ($this->mimetype == 'application/pdf') {
-          $command = "gs -dPDFA -dBATCH -dNOPAUSE -dUseCIEColor -sProcessColorModel=DeviceCMYK -sDEVICE=pdfwrite -sPDFACompatibilityPolicy=1 -sOutputFile=$output_file $this->temp_file &> /var/log/phpfunctions/cmd1.log";
+          $command = "gs -dPDFA -dBATCH -dNOPAUSE -dUseCIEColor -sProcessColorModel=DeviceCMYK -sDEVICE=pdfwrite -sPDFACompatibilityPolicy=1 -sOutputFile=$output_file $this->temp_file 2>&1";
           exec($command, $pdfa_output, $return);
           $log_message = "$dsid derivative created using GhostScript with command - $command || SUCCESS";
         }
         else {
-          $command = "java -jar /opt/jodconverter-core-3.0-beta-4/lib/jodconverter-core-3.0-beta-4.jar $this->temp_file $output_file &> /var/log/phpfunctions/cmd1.log";
+          $command = "java -jar /opt/jodconverter-core-3.0-beta-4/lib/jodconverter-core-3.0-beta-4.jar $this->temp_file $output_file 2>&1";
           exec($command, $pdfa_output, $return);
           $log_message = "$dsid derivative created using JODConverted and OpenOffice with command - $command || SUCCESS";
         }
-        $this->add_derivative($dsid, $label, $output_file, 'application/pdf', $log_message);
+        
+        if(file_exists($output_file))
+        {
+          $this->add_derivative($dsid, $label, $output_file, 'application/pdf', $log_message);
+        }
+        else {
+          $this->log->lwrite("Could not find the file '$output_file.html' for the HOCR derivative!\nTesseract output: " . implode(', ', $pdfa_output));
+          return $return;
+        }
       } catch (Exception $e) {
-        $this->log->lwrite("Could not create the $dsid derivative!", 'FAIL_DATASTREAM', $this->pid, $dsid, NULL, 'ERROR');
+        $this->log->lwrite("Could not create the $dsid derivative!", $return.' '.$pdfa_output,'FAIL_DATASTREAM', $this->pid, $dsid, NULL, 'ERROR');
         unlink($output_file);
       }
       return $return;

--- a/includes/Relationships.php
+++ b/includes/Relationships.php
@@ -42,7 +42,7 @@ XML;
       try{
         $return = $this->add_derivative($dsid, $label, $rels_int_str, 'text/xml', $log_message, FALSE, FALSE, 'X');
       } catch (Exception $e){
-        $this->log->lwrite('Error updating repository', 'PROCESS_DATASTREAM', $this->pid, $this->dsid);
+        $this->log->lwrite('Error updating repository', 'PROCESS_DATASTREAM', $this->pid, $this->incoming_dsid);
       }
     }
     else {
@@ -54,7 +54,7 @@ XML;
         $about = $description->getAttribute('rdf:about');
         $length = strlen($source_dsid);
         if (substr($about, -$length) === $source_dsid) {
-          $this->log->lwrite('Relationship already exists aborting', 'PROCESS_DATASTREAM', $this->pid, $this->dsid);
+          $this->log->lwrite('Relationship already exists aborting', 'PROCESS_DATASTREAM', $this->pid, $this->incoming_dsid);
           return 'Relationship already Exists';
         }
       }
@@ -73,7 +73,7 @@ XML;
       try{
         $return = $this->add_derivative($dsid, $label, $xml, 'text/xml', $log_message, FALSE, FALSE, 'X');
       } catch (Exception $e){
-        $this->log->lwrite('Error updating repository', 'PROCESS_DATASTREAM', $this->pid, $this->dsid);
+        $this->log->lwrite('Error updating repository', 'PROCESS_DATASTREAM', $this->pid, $this->incoming_dsid);
       }
     }
     return $return;

--- a/includes/Technical.php
+++ b/includes/Technical.php
@@ -1,7 +1,7 @@
 <?php
 
 class Technical extends Derivative {
-  
+
   function __destruct() {
     parent::__destruct();
   }
@@ -10,10 +10,16 @@ class Technical extends Derivative {
     $this->log->lwrite('Starting processing', 'PROCESS_DATASTREAM', $this->pid, $dsid);
     try {
       $output_file = $this->temp_file . '_TECHMD.xml';
-      $command = "/opt/fits/fits.sh -i $this->temp_file -o $output_file &> /var/log/phpfunctions/cmd1.log";
-      exec($command, $techmd_output, $return);
-      $log_message = "$dsid derivative created using FITS with command - $command || SUCCESS";
-      $this->add_derivative($dsid, $label, $output_file, 'text/xml', $log_message);
+      $command = "/opt/fits/fits.sh -i $this->temp_file -o $output_file 2>&1";
+      exec($command, $techmd_output = array(), $return);
+
+      if (file_exists($output_file . '.html')) {
+        $log_message = "$dsid derivative created using FITS with command - $command || SUCCESS";
+        $this->add_derivative($dsid, $label, $output_file, 'text/xml', $log_message);
+      }
+      else {
+        $this->log->lwrite("Could not find the file '$output_file' for the Techmd derivative!\nTesseract output: " . implode(', ', $techmd_output) . "\nReturn value: $return", 'FAIL_DATASTREAM', $this->pid, 'techmd', NULL, 'ERROR');
+      }
     } catch (Exception $e) {
       $this->log->lwrite("Could not create the $dsid derivative! " . $e->getMessage(), 'FAIL_DATASTREAM', $this->pid, $dsid, NULL, 'ERROR');
       unlink($output_file);
@@ -22,6 +28,7 @@ class Technical extends Derivative {
     unlink($output_file);
     return $return;
   }
+
 }
 
 ?>

--- a/soap_serv.php
+++ b/soap_serv.php
@@ -325,12 +325,12 @@ class IslandoraService {
    */
   function read($pid, $dsid, $extension) {
     try {
-      if (fedora_object_exists($this->fedora_url, $this->user, $pid)) {
+      if (fedora_object_exists($this->config->fedora->host, $this->config->fedora->username, $pid)) {
         $content = $this->fedora_connect->getDatastream($pid, $dsid)->content;
         return base64_encode($content);
       }
         } catch (Exception $e) {
-      $this->log->lwrite("An error occurred creating the fedora object", 'FAIL_OBJECT', $pid, NULL, $message->author, 'ERROR');
+      $this->log->lwrite("An error occurred creating the fedora object", 'FAIL_OBJECT', $pid, $e->getMessage(), 'ERROR');
         }
   }
 
@@ -365,7 +365,7 @@ class IslandoraService {
    * @param string $funcresult
    * @return int
    */
-  function getFunctionStatus($funcname, $funcresult) {
+  function getFunctionStatus($funcname, $funcresult,$pid,$dsid) {
     if ($funcresult == 0) {
       $this->log->lwrite($funcname . " function successful", 'SOAP_LOG', $pid, $dsid, NULL, 'INFO');
       $result = 0;
@@ -417,7 +417,7 @@ class IslandoraService {
       $result = -3;
     }
     $funcresult = $text->allOcr($outputdsid, $label, $language);
-    $result = $this->getFunctionStatus("allOcr", $funcresult);
+    $result = $this->getFunctionStatus("allOcr", $funcresult,$pid,$dsid);
     return $result;
   }
 
@@ -452,9 +452,7 @@ class IslandoraService {
       $result = -2;
         }
 
-
-
-    if ($text = new Text($fedora_object, $dsid, NULL, $this->log, null)) {
+    if ($text = new Text($fedora_object, $dsid,NULL, $this->log, null)) {
       $this->log->lwrite("Text derivative created", 'SOAP_LOG', $pid, $dsid, NULL, 'INFO');
     }
     else {
@@ -462,7 +460,7 @@ class IslandoraService {
       $result = -3;
     }
     $funcresult = $text->ocr($outputdsid, $label, $language);
-    $result = $this->getFunctionStatus("ocr", $funcresult);
+    $result = $this->getFunctionStatus("ocr", $funcresult,$pid,$dsid);
     return $result;
   }
 
@@ -506,7 +504,7 @@ class IslandoraService {
     }
 
     $funcresult = $text->hOcr($outputdsid, $label, $language);
-    $result = $this->getFunctionStatus("hOcr", $funcresult);
+    $result = $this->getFunctionStatus("hOcr", $funcresult,$pid,$dsid);
     return $result;
   }
 
@@ -548,7 +546,7 @@ class IslandoraService {
       $result = -3;
     }
     $funcresult = $text->encodedOcr($outputdsid, $label, $language);
-    $result = $this->getFunctionStatus("encodedOcr", $funcresult);
+    $result = $this->getFunctionStatus("encodedOcr", $funcresult,$pid,$dsid);
     return $result;
   }
 
@@ -613,7 +611,7 @@ class IslandoraService {
       $result = -3;
     }
     $funcresult = $image->jp2($outputdsid, $label);
-    $result = $this->getFunctionStatus("jp2", $funcresult);
+    $result = $this->getFunctionStatus("jp2", $funcresult,$pid,$dsid);
     return $result;
   }
 
@@ -658,7 +656,7 @@ class IslandoraService {
       $result = -3;
     }
     $funcresult = $image->tn($outputdsid, $label, $height, $width);
-    $result = $this->getFunctionStatus("tn", $funcresult);
+    $result = $this->getFunctionStatus("tn", $funcresult,$pid,$dsid);
     return $result;
   }
 
@@ -696,8 +694,8 @@ class IslandoraService {
       $this->log->lwrite("Derivative not created", 'SOAP_LOG', $pid, $dsid, NULL, 'ERROR');
       $result = -3;
     }
-    $funcresult = $tech->techmd($outputdsid, $label, $height, $width);
-    $result = $this->getFunctionStatus("techmd", $funcresult);
+    $funcresult = $tech->techmd($outputdsid, $label, $label);
+    $result = $this->getFunctionStatus("techmd", $funcresult,$pid,$dsid);
     return $result;
   }
 
@@ -736,7 +734,7 @@ class IslandoraService {
       $result = -3;
     }
     $funcresult = $pdf->scholarPdfa($outputdsid, $label);
-    $result = $this->getFunctionStatus("scholarPdfa", $funcresult);
+    $result = $this->getFunctionStatus("scholarPdfa", $funcresult,$pid,$dsid);
     return $result;
   }
 
@@ -774,8 +772,8 @@ class IslandoraService {
       $this->log->lwrite("Relationship class not loaded", 'SOAP_LOG', $pid, $dsid, NULL, 'ERROR');
       $result = -3;
     }
-    $funcresult = $rels->addImageDimensionsToRels($outputdsid, $label, $height, $width);
-    $result = $this->getFunctionStatus("encodedOcr", $funcresult);
+    $funcresult = $rels->addImageDimensionsToRels($outputdsid, $label);
+    $result = $this->getFunctionStatus("encodedOcr", $funcresult,$pid,$dsid);
     return $result;
   }
 
@@ -814,7 +812,7 @@ class IslandoraService {
       $result = -3;
     }
     $funcresult = $policy->scholarPolicy($outputdsid, $label);
-    $result = $this->getFunctionStatus("encodedOcr", $funcresult);
+    $result = $this->getFunctionStatus("encodedOcr", $funcresult,$pid,$dsid);
     return $result;
   }
 

--- a/soap_test/IslandoraServiceTest.php
+++ b/soap_test/IslandoraServiceTest.php
@@ -13,7 +13,6 @@ class IslandoraServiceTest extends PHPUnit_Framework_TestCase {
     $this->backupStaticAttributes = false;
 
     $this->islandoraServ = new IslandoraService();
-    $this->islandoraServ->fedora_connect = getFedoraMock($this);
   }
 
   function testRead() {


### PR DESCRIPTION
log path edited 
go through the unit test and get result:

[root@islandora php_listeners]# phpunit soap_test/
PHP Deprecated:  Assigning the return value of new by reference is deprecated in /usr/share/pear/HTTP/Request.php on line 412
PHP Deprecated:  Assigning the return value of new by reference is deprecated in /usr/share/pear/HTTP/Request.php on line 736
PHP Deprecated:  Assigning the return value of new by reference is deprecated in /usr/share/pear/HTTP/Request.php on line 749
PHP Deprecated:  Assigning the return value of new by reference is deprecated in /usr/share/pear/HTTP/Request.php on line 794

PHPUnit 3.7.21 by Sebastian Bergmann.

...........

Time: 7 seconds, Memory: 20.50Mb

OK (11 tests, 11 assertions)
