### PR TITLE
Patch for Taverna server 2.5.4 and self-signed certificate of soap server HTTPS

### DIFF
--- a/connect.php
+++ b/connect.php
@@ -268,9 +268,8 @@ class Connect {
       }
     } catch (Exception $e) {
       $this->log->lwrite($e->getMessage() . ' ' . $e->getCode(), 'TAVERNA_ERROR', $pid, $dsID, NULL, 'ERROR');
-      $response = $e->getResponse();
-      $responseString = $response['content'];
-      $taverna_sender->delete_t2flow($uuid); //try to delete the failed attempt on the taverna server
+      $responseString = $e->getMessage();
+      $response = $taverna_sender->delete_t2flow($uuid); //try to delete the failed attempt on the taverna server
       //we rest and retry here as the most common taverna error will probable be a 403 forbidden
       //due to the server being overloaded.  
       sleep(10);

--- a/tavernaSender.php
+++ b/tavernaSender.php
@@ -310,6 +310,7 @@ class TavernaSender extends Sender {
       throw new TavernaException("Authentication is required, but no users defined in microservice_users_file.xml ", 'send credentials');
     }
     $host = $this->hostname . $uuid . '/security/credentials';
+    $hostTrust = $this->hostname . $uuid . '/security/trusts';
     foreach ($users as $user) {
       $data = '<credential xmlns="http://ns.taverna.org.uk/2010/xml/server/rest/">
         <userpass xmlns="http://ns.taverna.org.uk/2010/xml/server/">
@@ -321,6 +322,15 @@ class TavernaSender extends Sender {
       $response = $this->curl_connect->postRequest($host, 'String', $data, 'application/xml');
       if ($response['status'] != 201) {
         throw new TavernaException('Error sending credentials ' . $response['headers'] . $response['content'], $response['status'], 'send credentials');
+      }
+      if ($user['trustCA'] != ""){
+        $data = '<trustedIdentity xmlns="http://ns.taverna.org.uk/2010/xml/server/">
+          <certificateBytes xmlns="http://ns.taverna.org.uk/2010/xml/server/">' . $user['trustCA'] . '</certificateBytes>
+          </trustedIdentity>';
+        $response = $this->curl_connect->postRequest($hostTrust, 'String', $data, 'application/xml');
+        if ($response['status'] != 201) {
+          throw new TavernaException('Error sending trusted Identity ' . $response['headers'] . $response['content'], $response['status'], 'send trustedIdentity');
+        }
       }
     }
     return TRUE;

--- a/tavernaSender.php
+++ b/tavernaSender.php
@@ -182,7 +182,7 @@ class TavernaSender extends Sender {
 
     $url = $this->hostname . $uuid . '/status/';
     $response = $this->curl_connect->tavernaPutRequest($url, 'string', 'Operating', 'text/plain');
-    if ($response['status'] != 200) {
+    if (($response['status'] != 200) && ($response['status'] != 202)) {
       throw new TavernaException($response['headers'] . $response['content'], $response['status'], 'run t2flow');
     }
     return $response['headers'] . $response['content'];


### PR DESCRIPTION
Added patch for response code 202 returned by version 2.5.4 and add option to pass public certificate to Taverna server to use for connection to soap service with HTTPS and self-signed certificate.
